### PR TITLE
Fix Duktape GC description

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The following is a list of reasonably mature open source embedded scripting lang
 | [ChaiScript](http://chaiscript.com/) | C++ | Ref. counting | 3-clause BSD | |
 | [Chibi Scheme](https://github.com/ashinn/chibi-scheme) | C | Tracing | 3-clause BSD | Implements R7RS small. |
 | [Clasp](https://github.com/drmeister/clasp) | Common Lisp, C++ | MPS GC (Boehm-Weiser also supported) | LGPL 2+ | Full Common Lisp implementation well integrated with C++, using LLVM for the code generation, to integrate closely with C++ applications or libraries. |
-| [Duktape](http://duktape.org/) | C | Tracing | MIT | Implements JavaScript E5/E5.1. |
+| [Duktape](http://duktape.org/) | C | Ref. counting + Tracing | MIT | Implements JavaScript E5/E5.1. |
 | [DWScript](https://bitbucket.org/egrange/dwscript/) | Object Pascal (Delphi 2009 or later) | Ref. counting + cycle-detecting GC | MPL 1.1, GPL 3 (JavaScript code generator) | [Description](https://www.delphitools.info/dwscript). A statically typed Delphi/Free Pascal-like language. Can compile to JavaScript. |
 | [Embeddable Common Lisp](https://gitlab.com/embeddable-common-lisp/ecl) | Common Lisp, C | Boehm-Weiser GC | LGPL 2+ | Full Common Lisp implementation, available as a shared library libecl.so embeddable in any C, C++ or other application. |
 | [Espruino](https://github.com/espruino/Espruino) | C | Tracing | MPL 2.0 | Implements a subset of JavaScript ES5 in a way suitable for embedded hardware with 8+ KiB RAM. |


### PR DESCRIPTION
Duktape GC is reference counting + mark-and-sweep for cyclic objects. Reference counting can also be disabled.