### PR TITLE
Add Red programming language

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The following is a list of reasonably mature open source embedded scripting lang
 | [Python](https://www.python.org/) | C | Ref. counting + cycle-detecting tracing GC | PSFL (BSD-like) | [Embedding Python in Another Application](https://docs.python.org/3.5/extending/embedding.html). |
 | [gmqcc/qcvm](https://github.com/graphitemaster/gmqcc) | C++ | None (no dynamic memory allocation) | MIT | A QuakeC compiler and VM. |
 | [QuickJS](https://bellard.org/quickjs/) | C | Ref. counting + cycle-detecting tracing GC | MIT | A small embedded JavaScript interpreter that implements almost all of ES2019 and much of ES2020. |
+| [Red](https://github.com/red/red) | Rebol, Red, Red/System | Tracing | 3-clause BSD and BSL | Rebol's descendant with a wider scope of usage, from metal to meta. Embeddable via [libRed](https://doc.red-lang.org/en/libred.html#_abstract), features cross-platform native GUI system and low-footprint language runtime. |
 | [Rhai](https://github.com/jonathandturner/rhai) | Rust | ? | MIT or Apache License 2.0 | An embedded scripting language for Rust inspired by ChaiScript. |
 | [Ring](https://github.com/ring-lang/ring) | C | Tracing | MIT | An embeddable applications programming language with a large standard library and GIL-less multithreading. |
 | [Ruby](https://www.ruby-lang.org/en/) | C | Tracing | Choice of 2-clause BSD, Ruby license, GPL 2 | An embeddable object-oriented scripting language. [Running Ruby in C](https://silverhammermba.github.io/emberb/embed/). |


### PR DESCRIPTION
More details about the project can be found [here](https://www.red-lang.org/p/about.html). See also [examples](https://www.red-lang.org/2017/03/062-libred-and-macros.html) of libRed usage.