### PR TITLE
Added Rhai's GC information

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The following is a list of reasonably mature open source embedded scripting lang
 | [gmqcc/qcvm](https://github.com/graphitemaster/gmqcc) | C++ | None (no dynamic memory allocation) | MIT | A QuakeC compiler and VM. |
 | [QuickJS](https://bellard.org/quickjs/) | C | Ref. counting + cycle-detecting tracing GC | MIT | A small embedded JavaScript interpreter that implements almost all of ES2019 and much of ES2020. |
 | [Red](https://github.com/red/red) | Rebol, Red, Red/System | Tracing | 3-clause BSD, BSL | A descendant of Rebol.  Embeddable via [libRed](https://doc.red-lang.org/en/libred.html#_abstract).  Features a cross-platform native GUI system.  Intended to have low memory usage. |
-| [Rhai](https://github.com/jonathandturner/rhai) | Rust | ? | MIT or Apache License 2.0 | An embedded scripting language for Rust inspired by ChaiScript. |
+| [Rhai](https://github.com/jonathandturner/rhai) | Rust | None (Rust-style lifetimes) | MIT or Apache License 2.0 | An embedded scripting language for Rust inspired by ChaiScript. |
 | [Ring](https://github.com/ring-lang/ring) | C | Tracing | MIT | An embeddable applications programming language with a large standard library and GIL-less multithreading. |
 | [Ruby](https://www.ruby-lang.org/en/) | C | Tracing | Choice of 2-clause BSD, Ruby license, GPL 2 | An embeddable object-oriented scripting language. [Running Ruby in C](https://silverhammermba.github.io/emberb/embed/). |
 | [s7](https://ccrma.stanford.edu/software/snd/snd/s7.html) | C | Tracing | 3-clause BSD | Implements a subset of R5RS/R7RS. Descended from TinyScheme. |


### PR DESCRIPTION
As seen here: https://github.com/jonathandturner/rhai/blob/f3e02fcd0313a0f240042f7d3df5b8e9be1ed723/src/engine.rs#L620-L645

On execution, the scope has a snapshot taken by storing the number of items currently in scope prior to executing, allows that to be mutated, and then disposes of all new items in scope afterwards.
Anything that is exposed to something in an outer scope is referenced using copy-on-write, which is reference counted.

I'm not sure if I should call this reference counted or none/scope-based as the internal implementation of Rust's standard Cow type uses a reference counted pointer, but the logic of the engine does not follow this pattern.