### PR TITLE
Add the Moirai programming language

### DIFF
--- a/data/projects.toml
+++ b/data/projects.toml
@@ -568,6 +568,14 @@ gc = "Tracing"
 license = "MIT"
 notes = "Implements the Python 3.4 syntax and some of the core datatypes."
 
+[Moirai]
+url = "https://github.com/moirai-lang/moirai-kt"
+lang = "Moirai"
+impl_in = "Kotlin"
+gc = "JVM's GC"
+license = "MIT"
+notes = "A scripting language that calculates the worst-case execution time (WCET) before executing each script. Ideal for multi-tenant microservices and serverless applications."
+
 [Molt]
 url = "https://github.com/wduquette/molt"
 lang = "Tcl"


### PR DESCRIPTION
This change adds the Moirai programming language to the data. I did not regenerate the README.md. If I should have done so, let me know.

The public surface of the Moirai language has been locked down recently using the Kotlin **internal** keyword. Changes to the language should be backward compatible. The language can currently be used in production.