### PR TITLE
Add Tengo

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ To sort and filter the list interactively, visit the [webpage](https://dbohdan.g
 | Tcl | [Molt](https://github.com/wduquette/molt) | Rust | Ref. counting | BSD-3-Clause | A minimal Tcl implementation designed for Rust applications and libraries. |
 | Tcl | [Picol](https://chiselapp.com/user/dbohdan/repository/picol/) | C | None (no reference support) | BSD-2-Clause | A header-only library interpreter for a limited dialect of Tcl. |
 | Tcl | [Tcl](http://tcl-lang.org/) | C | Ref. counting | Tcl license (BSD-like) | An embeddable general-purpose scripting language with a rich C API. Includes a cross-platform GUI toolkit called [Tk](https://wiki.tcl-lang.org/477). See ["How to embed Tcl in C applications"](https://wiki.tcl-lang.org/2074). |
+| Tengo | [Tengo](https://github.com/d5/tengo) | Go | Go&#39;s GC | MIT | A dynamic script language for Go. |
 | Toy | [Toy](https://github.com/Ratstail91/Toy) | C | Ref. counting | Zlib | Has an optional type system. [Embedding Toy](https://toylang.com/deep-dive/embedding-toy). |
 | Umka | [Umka](https://github.com/vtereshkov/umka-lang) | C | Ref. counting | BSD-2-Clause | Statically typed. |
 | Wirefilter | [Wirefilter](https://github.com/cloudflare/wirefilter) | Rust | None (no dynamic memory allocation) | MIT | An expression language for Wireshark-like filters. |

--- a/data/projects.toml
+++ b/data/projects.toml
@@ -1096,6 +1096,14 @@ gc = "None"
 license = "LGPL-2.0-only"
 notes = "A small C compiler that can be used as a library for a C JIT. [libtcc header](https://repo.or.cz/tinycc.git/blob/HEAD:/libtcc.h). [Embedding example](https://repo.or.cz/tinycc.git/blob/HEAD:/tests/libtcc_test.c)."
 
+[Tengo]
+url = "https://github.com/d5/tengo"
+lang = "Tengo"
+impl_in = "Go"
+gc = "Go's GC"
+license = "MIT"
+notes = "A dynamic script language for Go."
+
 [TinyScheme]
 url = "http://tinyscheme.sourceforge.net/"
 lang = "Scheme"


### PR DESCRIPTION
Added Tengo, "a fast script language for Go".

* Actively maintained, [last commit](https://github.com/d5/tengo/commit/1ac160c10024a1fe81278791a55fdac0f04af559) 2 weeks ago
* [Embeddable](https://github.com/d5/tengo/blob/v3.0.0/README.md?plain=1#L39C13-L39C23)
* [MIT license](https://github.com/d5/tengo/blob/v3.0.0/LICENSE)